### PR TITLE
Apply sign-off review feedback

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,21 +12,21 @@
 :projectid: istio-intro
 :page-layout: guide
 :page-duration: 30 minutes
-:page-releasedate: 2018-06-30
-:page-description: Explore how to set up your microservices for blue-green deployments using Istio.
+:page-releasedate: 2019-02-01
+:page-description: Explore how to manage microservice traffic using Istio.
 :page-tags: ['Kubernetes', 'Docker']
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['docker', 'kubernetes-intro', 'kubernetes-microprofile-config', 'kubernetes-microprofile-health']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
 :page-seo-title: Managing microservice traffic using Istio
-:page-seo-description: Managing traffic with Istio to implement blue-green deployments
+:page-seo-description: How to manage microservice traffic with Istio
 = Managing microservice traffic using Istio
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].
 
-Explore how to use Istio to implement blue-green deployments for your microservices.
+Explore how to manage microservice traffic using Istio.
 
 :kube: Kubernetes
 :istio: Istio
@@ -41,15 +41,15 @@ Explore how to use Istio to implement blue-green deployments for your microservi
 == What you'll learn
 
 You will learn how to deploy an application to a Kubernetes cluster and enable {istio} on it. You will also learn how to configure
-{istio} to shift traffic to implement blue-green deployments.
+{istio} to shift traffic to implement blue-green deployments for microservices.
 
 === What is {istio}?
 
-https://istio.io/[{istio}] is a platform for managing how microservices interact with each other and the outside world.
+https://istio.io/[{istio}] is a service mesh, meaning that it's a platform for managing
+how microservices interact with each other and the outside world.
 {istio} consists of a control plane and sidecars injected into application pods. The sidecars contain
-the https://www.envoyproxy.io/[Envoy] proxy. You can think of Envoy as a sidecar that intercepts and controls all the traffic to and from your container. 
-
-{istio} is a service mesh, meaning that a sidecar proxy is deployed with each microservice. The proxy is a sidecar that deals with HTTP and TCP traffic.
+the https://www.envoyproxy.io/[Envoy] proxy. You can think of Envoy as a sidecar that intercepts and
+controls all the traffic to and from your container, it deals with HTTP and TCP traffic.
 
 While {istio} runs on top of {kube} and that will be the focus of this guide, note that {istio}
 can also be used with other environments such as Docker Compose. {istio} has many features such as
@@ -57,11 +57,11 @@ traffic shifting, request routing, access control, and distributed tracing, but 
 
 === Why {istio}?
 
-{istio}'s routing features allow you to route HTTP requests based on several factors such as HTTP headers or cookies.
-A possible use case for {istio}'s Telemetry feature is to enable distributed tracing. Distributed tracing allows you
+{istio} provides a collection of features that allows you to manage several aspects of your services.
+One example is {istio}'s routing features, it allows you to route HTTP requests based on several factors such as HTTP headers or cookies.
+Another use case for {istio} is Telemetry, which can be used to enable distributed tracing. Distributed tracing allows you
 to visualize how HTTP requests travel between different services in your cluster using a tool such as https://www.jaegertracing.io/[Jaeger].
-One of the items {istio} offers under its collection of security features is to enable mutual TLS between pods
-in your cluster. Enabling HTTPS between pods secures communication between microservices internally.
+Finally, one of the items {istio} offers under its collection of security features is to enable mutual TLS between pods in your cluster. Enabling HTTPS between pods secures communication between microservices internally.
 
 You'll use {istio} to implement blue-green deployments. The traffic shifting features allows you to allocate a percentage of
 traffic to certain versions of services. This feature can be used to shift 100 percent of live traffic to blue deployments and 100 percent
@@ -248,7 +248,7 @@ hello-deployment-blue    1         1         1            1           1m
 hello-deployment-green   1         1         1            1           1m
 ----
 
-Once all the deployments are available, you will make a request to v1 of the deployed application. As defined in `hello.yaml` the gateway is expecting the host to be `example.com`. Requests to `example.com` won't be routed to the appropriate IP address. Ensure to set the `Host` header appropriately so the gateway routes your requests appropriately.
+Once all the deployments are available, you will make a request to v1 of the deployed application. As defined in `hello.yaml` the gateway is expecting the host to be `example.com`. Requests to `example.com` won't be routed to the appropriate IP address. Ensure that the `Host` header is set to `example.com` so the gateway routes your requests appropriately, for instance, with the `-H` option of the `curl` command.
 
 ****
 [system]#*{win} | {mac}*#

--- a/README.adoc
+++ b/README.adoc
@@ -13,26 +13,29 @@
 :page-layout: guide
 :page-duration: 30 minutes
 :page-releasedate: 2018-06-30
-:page-description: Explore how to set up your microservices for blue green deployments using Istio.
+:page-description: Explore how to set up your microservices for blue-green deployments using Istio.
 :page-tags: ['Kubernetes', 'Docker']
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['docker', 'kubernetes-intro', 'kubernetes-microprofile-config', 'kubernetes-microprofile-health']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/master
 :source-highlighter: prettify
 :page-seo-title: Managing microservice traffic using Istio
-:page-seo-description: Managing traffic with Istio to implement blue green deployments
+:page-seo-description: Managing traffic with Istio to implement blue-green deployments
 = Managing microservice traffic using Istio
 
 [.hidden]
 NOTE: This repository contains the guide documentation source. To view the guide in published form, view it on the https://openliberty.io/guides/{projectid}.html[Open Liberty website].
 
-Explore how to use Istio to implement blue green deployments for your microservices.
+Explore how to use Istio to implement blue-green deployments for your microservices.
 
 :kube: Kubernetes
 :istio: Istio
 :win: WINDOWS
 :mac: MAC
 :linux: LINUX
+:docker: Docker
+:minikube: Minikube
+:maven: Maven
 
 
 == What you'll learn
@@ -40,17 +43,13 @@ Explore how to use Istio to implement blue green deployments for your microservi
 You will learn how to deploy an application to a Kubernetes cluster and enable {istio} on it. You will also learn how to configure
 {istio} to shift traffic to implement blue-green deployments.
 
-The microservice you'll deploy is called `hello`. It responds with a JSON object that has a version number and a greeting. The version number will be automatically incremented when you update the `pom.xml` version. This number will allow you to view which version of the microservice is running in your production or testing environments.
-
-You will use the `kubectl` command-line tool to deploy your {kube} resources. You'll use the `istioctl` command-line tool to inject {istio} sidecars into your pods.
-
 === What is {istio}?
 
 https://istio.io/[{istio}] is a platform for managing how microservices interact with each other and the outside world.
 {istio} consists of a control plane and sidecars injected into application pods. The sidecars contain
 the https://www.envoyproxy.io/[Envoy] proxy. You can think of Envoy as a sidecar that intercepts and controls all the traffic to and from your container. 
 
-{istio} is a service mesh, meaning that a sidecar proxy is deployed with each microservice. The proxy is a sidecar that deals with HTTP and TCP traffic. It provides routing, monitoring, security, operations features for microservices.
+{istio} is a service mesh, meaning that a sidecar proxy is deployed with each microservice. The proxy is a sidecar that deals with HTTP and TCP traffic.
 
 While {istio} runs on top of {kube} and that will be the focus of this guide, note that {istio}
 can also be used with other environments such as Docker Compose. {istio} has many features such as
@@ -58,24 +57,22 @@ traffic shifting, request routing, access control, and distributed tracing, but 
 
 === Why {istio}?
 
-{istio} provides a collection of features that allow you to manage several aspects of your services
-such as: Routing, Telemetry, and Security. These features can be easily configured transparently to your
-application's code.
-
 {istio}'s routing features allow you to route HTTP requests based on several factors such as HTTP headers or cookies.
 A possible use case for {istio}'s Telemetry feature is to enable distributed tracing. Distributed tracing allows you
-to visualize how HTTP requests travel between different services in your cluster using a tool such as https://zipkin.io/[Zipkin].
+to visualize how HTTP requests travel between different services in your cluster using a tool such as https://www.jaegertracing.io/[Jaeger].
 One of the items {istio} offers under its collection of security features is to enable mutual TLS between pods
 in your cluster. Enabling HTTPS between pods secures communication between microservices internally.
 
-You'll use {istio} to implement blue green deployments. The traffic shifting features allow you to allocate a percentage of
+You'll use {istio} to implement blue-green deployments. The traffic shifting features allows you to allocate a percentage of
 traffic to certain versions of services. This feature can be used to shift 100 percent of live traffic to blue deployments and 100 percent
 of testing traffic to green deployments. Then, you can shift the traffic to point to the opposite deployments as is necessary to
-perform blue green deployments.
+perform blue-green deployments.
 
-=== What are blue green deployments?
+The microservice you'll deploy is called `hello`. It responds with a JSON object that has a version number and a greeting. The version number will be automatically incremented when you update the `pom.xml` version. This number will allow you to view which version of the microservice is running in your production or testing environments.
 
-Blue green deployments are a way of deploying your applications such that you have two environments where your application runs. In this scenario, there will be a production environment and a testing environment. At any point in time the blue deployment may be accepting production traffic and the green accepting testing traffic or vice-versa. When you want to deploy a new version of your application, you will deploy to the color that is currently acting as your testing environment. Once the new version is verified on the testing environment, the traffic will be shifted over. Thus, your live traffic is now coming from what used to be the testing site.
+=== What are blue-green deployments?
+
+Blue-green deployments are a way of deploying your applications such that you have two environments where your application runs. In this scenario, there will be a production environment and a testing environment. At any point in time the blue deployment may be accepting production traffic and the green accepting testing traffic or vice-versa. When you want to deploy a new version of your application, you will deploy to the color that is currently acting as your testing environment. Once the new version is verified on the testing environment, the traffic will be shifted over. Thus, your live traffic is now being handled by what used to be the testing site.
 
 // =================================================================================================
 // Prerequisites
@@ -126,7 +123,7 @@ the deployment is complete.
 kubectl get deployments -n istio-system
 ```
  
-Ensure that the istio deployments are all available before continuing, it may take a few minutes for all of them to be available. If the deployments aren't available after a few minutes, then increase the amount of memory available to your {kube} cluster. On Docker Desktop, this can be done from your Docker preferences. On minikube, this can be done using the `--memory` flag.
+Ensure that the {istio} deployments are all available before continuing, it may take a few minutes for all of them to be available. If the deployments aren't available after a few minutes, then increase the amount of memory available to your {kube} cluster. On Docker Desktop, this can be done from your {docker} preferences. On {minikube}, this can be done using the `--memory` flag.
 [source, role="no_copy"]
 ----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
@@ -144,27 +141,31 @@ prometheus               1         1         1            1           44s
 servicegraph             1         1         1            1           44s
 ----
 
-Finally, enable automatic sidecar injection.
+Finally, create the `istio-injection` label and set its value to `enabled`.
 
 ```
 kubectl label namespace default istio-injection=enabled
 ```
 
+Adding this label enables automatic {istio} sidecar injection. Automatic injection means that sidecars will
+automatically be injected into your pods when you deploy your application. You don't need to perform
+any additional steps for the sidecars to be injected.
+
 // =================================================================================================
-// Deploying v1 of the service to cluster
+// Deploying v1
 // =================================================================================================
 
-== Deploying version 1 of the service to the cluster
+== Deploying version 2 of the hello microservice
 
 Navigate to the `start` directory and run the following command. It may take a few minutes to complete.
-It will build the application and then package it into a docker image.
-To build the docker image, it uses a maven plug-in called `dockerfile-maven-plugin`.
+It will build the application and then package it into a {docker} image.
+To build the {docker} image, it uses a {maven} plug-in called `dockerfile-maven-plugin`.
 
 ```
 mvn clean package
 ```
 
-After running the command, it builds a docker image for the `hello` microservice.
+After running the command, it builds a {docker} image for the `hello` microservice.
 You can verify that this image was created by running the given command. 
 
 ```
@@ -247,7 +248,7 @@ hello-deployment-blue    1         1         1            1           1m
 hello-deployment-green   1         1         1            1           1m
 ----
 
-Once all the deployments are available, you will make a request to v1 of the deployed application. As defined in `hello.yaml` the gateway is expecting the host to be `example.com`. Ensure to set the `Host` header appropriately.
+Once all the deployments are available, you will make a request to v1 of the deployed application. As defined in `hello.yaml` the gateway is expecting the host to be `example.com`. Requests to `example.com` won't be routed to the appropriate IP address. Ensure to set the `Host` header appropriately so the gateway routes your requests appropriately.
 
 ****
 [system]#*{win} | {mac}*#
@@ -258,7 +259,10 @@ Make a request to the service by using `curl`.
 curl -HHost:example.com http://localhost/hello
 ```
 
-If `curl` is unavailable, then use https://www.getpostman.com/[Postman].
+If `curl` is unavailable, then use https://www.getpostman.com/[Postman]. Postman enables you
+to make requests using a graphical interface. To make a request with Postman, enter `http://localhost/hello`
+into the URL bar. Next, switch to the `Headers` tab and add a header with key `Host` and value `example.com`.
+Finally, click the blue `Send` button to make the request.
 
 [system]#*{linux}*#
 
@@ -282,13 +286,13 @@ You'll see a greeting message along with a corresponding version.
 
 == Deploying version 2 of the hello microservice
 
-The `hello` microservice is set up to respond with the version that is set in the `pom.xml` file. The tag for the docker image is also dependent on the version specified in the `pom.xml` file. Use the maven command to bump the version of the microservice to `2.0-SNAPSHOT`.
+The `hello` microservice is set up to respond with the version that is set in the `pom.xml` file. The tag for the {docker} image is also dependent on the version specified in the `pom.xml` file. Use the {maven} command to bump the version of the microservice to `2.0-SNAPSHOT`.
 
 ```
 mvn versions:set -DnewVersion=2.0-SNAPSHOT
 ```
 
-Build the new version of the docker container.
+Build the new version of the {docker} container.
 
 ```
 mvn clean package
@@ -356,6 +360,7 @@ curl -HHost:example.com http://localhost/hello
 ```
 
 If `curl` is unavailable, then use https://www.getpostman.com/[Postman].
+
 [system]#*{linux}*#
 
 Make a request to the service by using `curl`.
@@ -405,7 +410,7 @@ mvn verify -Ddockerfile.skip=true -Dcluster.ip=`minikube ip` -Dport=31380
 The `cluster.ip` and `port` parameters refer to the IP address and port for the {istio} gateway.
 ****
 
-The `dockerfile.skip=true` flag skips rebuilding the docker images.
+The `dockerfile.skip=true` flag skips rebuilding the {docker} images.
 
 If the tests pass, then you should see output similar to the following:
 
@@ -432,7 +437,8 @@ kubectl delete -f hello.yaml
 kubectl delete -f traffic.yaml
 ```
 
-Delete the `istio-injection` label from the default namespace.
+Delete the `istio-injection` label from the default namespace. The hyphen immediately
+after the label name indicates that the label should be deleted.
 
 ```
 kubectl label namespace default istio-injection-


### PR DESCRIPTION
* Capitalize proper nouns
* Hyphenate blue-green deployments
* Make deploying service section titles consistent with eachother
* Change Zipkin to Jaeger
* More detailed description on the istio-injection label
* Explain hyphen in the label deletion command
* Explain host header with more detail and add instructions to make a request with Postman
* Re-organize and fix introduction
* Fix 'LINUX' positioning