### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
 - package-ecosystem: maven
-  directory: "/"
+  directory: "/finish"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50
+- package-ecosystem: maven
+  directory: "/start"
   schedule:
     interval: monthly
   open-pull-requests-limit: 50

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -3,7 +3,6 @@ name: Add PRs to Dependabot PRs dashboard
 on:
   pull_request:
     types:
-      - opened
       - labeled
 
 jobs:

--- a/.github/workflows/add-pr-to-project.yml
+++ b/.github/workflows/add-pr-to-project.yml
@@ -1,0 +1,18 @@
+name: Add PRs to Dependabot PRs dashboard
+
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+
+jobs:
+  add-to-project:
+    name: Add PR to dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/OpenLiberty/projects/26
+          github-token: ${{ secrets.ADMIN_BACKLOG }}
+          labeled: dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
         uses: github/super-linter@v3.17.0
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_KUBERNETES_KUBEVAL: false
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: ./tools/pr-checker/linters/
           DEFAULT_BRANCH: prod

--- a/README.adoc
+++ b/README.adoc
@@ -493,7 +493,7 @@ Delete all {istio} resources from the cluster:
 
 [role=command]
 ```
-istioctl x uninstall --purge
+istioctl uninstall --purge
 ```
 
 include::{common-includes}/os-tabs.adoc[]

--- a/README.adoc
+++ b/README.adoc
@@ -154,8 +154,8 @@ You'll see an image called `system:1.0-SNAPSHOT` listed in a table similar to th
 ----
 REPOSITORY                     TAG                              IMAGE ID        CREATED          SIZE
 system                         1.0-SNAPSHOT                     8856039f4c42    9 minutes ago    745MB
-istio/proxyv2                  1.7.3                            7a3aaffcf645    3 weeks ago      347MB
-istio/pilot                    1.7.3                            4974b5b22dcc    3 weeks ago      261MB
+istio/proxyv2                  1.20.3                           7a3aaffcf645    3 weeks ago      347MB
+istio/pilot                    1.20.3                           4974b5b22dcc    3 weeks ago      261MB
 icr.io/appcafe/open-liberty    kernel-slim-java11-openj9-ubi    d6ef646493e1    8 days ago       729MB
 ----
 

--- a/README.adoc
+++ b/README.adoc
@@ -107,7 +107,7 @@ include::{common-includes}/gitclone.adoc[]
 // =================================================================================================
 // visit https://cdn.dl.k8s.io/release/stable.txt to get the latest stable version
 
-:minikube-start: minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.29.2
+:minikube-start: minikube start --memory=8192 --cpus=4
 :docker-desktop-description: Check your settings to ensure that you have an adequate amount of memory allocated to your Docker Desktop enviornment, 8GB is recommended but 4GB should be adequate if you don't have enough RAM.
 :minikube-description: The memory flag allocates 8GB of memory to your Minikube cluster. If you don't have enough RAM, then 4GB should be adequate.
 [role=command]

--- a/README.adoc
+++ b/README.adoc
@@ -105,6 +105,7 @@ include::{common-includes}/gitclone.adoc[]
 // =================================================================================================
 // Staring and preparing your cluster for deployment
 // =================================================================================================
+// visit https://cdn.dl.k8s.io/release/stable.txt to get the latest stable version
 
 :minikube-start: minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.29.2
 :docker-desktop-description: Check your settings to ensure that you have an adequate amount of memory allocated to your Docker Desktop enviornment, 8GB is recommended but 4GB should be adequate if you don't have enough RAM.

--- a/README.adoc
+++ b/README.adoc
@@ -1,7 +1,7 @@
 // INSTRUCTION: Please remove all comments that start INSTRUCTION prior to commit. Most comments should be removed, although not the copyright.
 // INSTRUCTION: The copyright statement must appear at the top of the file
 //
-// Copyright (c) 2017, 2023 IBM Corporation and others.
+// Copyright (c) 2017, 2024 IBM Corporation and others.
 // Licensed under Creative Commons Attribution-NoDerivatives
 // 4.0 International (CC BY-ND 4.0)
 //   https://creativecommons.org/licenses/by-nd/4.0/
@@ -14,7 +14,7 @@
 :page-duration: 30 minutes
 :page-releasedate: 2019-02-01
 :page-description: Explore how to manage microservice traffic using Istio.
-:page-tags: ['Kubernetes', 'Docker']
+:page-tags: ['kubernetes', 'docker']
 :page-permalink: /guides/{projectid}
 :page-related-guides: ['docker', 'kubernetes-intro', 'kubernetes-microprofile-config', 'kubernetes-microprofile-health']
 :common-includes: https://raw.githubusercontent.com/OpenLiberty/guides-common/prod
@@ -106,7 +106,7 @@ include::{common-includes}/gitclone.adoc[]
 // Staring and preparing your cluster for deployment
 // =================================================================================================
 
-:minikube-start: minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.19.0
+:minikube-start: minikube start --memory=8192 --cpus=4 --kubernetes-version=v1.29.2
 :docker-desktop-description: Check your settings to ensure that you have an adequate amount of memory allocated to your Docker Desktop enviornment, 8GB is recommended but 4GB should be adequate if you don't have enough RAM.
 :minikube-description: The memory flag allocates 8GB of memory to your Minikube cluster. If you don't have enough RAM, then 4GB should be adequate.
 [role=command]

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10</version>
+                <version>3.10.2</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>

--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -18,8 +18,8 @@
         <port>80</port>
         <host-header>example.com</host-header>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
         <liberty.var.app.version>${project.version}</liberty.var.app.version>
     </properties>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -71,19 +71,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <app.name>${project.version}</app.name>

--- a/finish/src/main/liberty/config/server.xml
+++ b/finish/src/main/liberty/config/server.xml
@@ -5,14 +5,14 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
   <variable name="app.version" defaultValue="1.0-SNAPSHOT"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="system.war" contextRoot="/"/>
 </server>

--- a/finish/src/main/webapp/index.html
+++ b/finish/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,11 +34,11 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
             </ul>
         </div>

--- a/finish/system.yaml
+++ b/finish/system.yaml
@@ -22,7 +22,7 @@ metadata:
     app: system
 spec:
   ports:
-  - port: 9080
+  - port: 9090
     name: http
   selector:
     app: system
@@ -47,7 +47,7 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -69,7 +69,7 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/finish/traffic.yaml
+++ b/finish/traffic.yaml
@@ -11,13 +11,13 @@ spec:
   - route:
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: blue
       weight: 0
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: green
       weight: 100
@@ -35,13 +35,13 @@ spec:
   - route:
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: blue
       weight: 100
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: green
       weight: 0

--- a/scripts/installIstio.sh
+++ b/scripts/installIstio.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ISTIO_LATEST=1.11.2
+ISTIO_LATEST=1.20.0
 
 apt install socat
 

--- a/scripts/installIstio.sh
+++ b/scripts/installIstio.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ISTIO_LATEST=1.20.0
+ISTIO_LATEST=1.20.3
 
 apt install socat
 

--- a/scripts/startMinikube.sh
+++ b/scripts/startMinikube.sh
@@ -23,7 +23,7 @@ systemctl enable cri-docker.service
 systemctl enable --now cri-docker.socket
 
 # install crictl
-VERSION="v1.24.2"
+VERSION="v1.29.0"
 wget "https://github.com/kubernetes-sigs/cri-tools/releases/download/$VERSION/crictl-$VERSION-linux-amd64.tar.gz"
 tar zxvf "crictl-$VERSION-linux-amd64.tar.gz" -C /usr/local/bin
 rm -f "crictl-$VERSION-linux-amd64.tar.gz"

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -71,7 +71,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.10</version>
+                <version>3.10.2</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -18,8 +18,8 @@
         <port>80</port>
         <host-header>example.com</host-header>
         <!-- Liberty configuration -->
-        <liberty.var.default.http.port>9080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9443</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9453</liberty.var.https.port>
         <liberty.var.app.version>${project.version}</liberty.var.app.version>
     </properties>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -42,19 +42,19 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-client</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
             <artifactId>resteasy-json-binding-provider</artifactId>
-            <version>6.2.3.Final</version>
+            <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -71,19 +71,19 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run unit tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <app.name>${project.version}</app.name>

--- a/start/src/main/liberty/config/server.xml
+++ b/start/src/main/liberty/config/server.xml
@@ -5,14 +5,14 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="9080"/>
-  <variable name="default.https.port" defaultValue="9443"/>
+  <variable name="http.port" defaultValue="9090"/>
+  <variable name="https.port" defaultValue="9453"/>
   <variable name="app.version" defaultValue="1.0-SNAPSHOT"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}" id="defaultHttpEndpoint"/>
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}" id="defaultHttpEndpoint"/>
 
   <webApplication location="system.war" contextRoot="/"/>
 </server>

--- a/start/src/main/webapp/index.html
+++ b/start/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -34,11 +34,11 @@
         <div id="technologies">
             <p>For more information about the features used in the application, see the Open Liberty documentation:</p>
             <ul>
-                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html">MicroProfile 6.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html">MicroProfile 6.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html">Jakarta RESTful Web Services 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html">Jakarta JSON Processing 2.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html">Jakarta Contexts and Dependency Injection 4.0</a></li>
-                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html">MicroProfile Config 3.0</a></li>
+                <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html">MicroProfile Config 3.1</a></li>
                 <li><a href="https://openliberty.io/docs/ref/feature/#jsonb-3.0.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Binding 3.0</a></li>
             </ul>
         </div>

--- a/start/system.yaml
+++ b/start/system.yaml
@@ -22,7 +22,7 @@ metadata:
     app: system
 spec:
   ports:
-  - port: 9080
+  - port: 9090
     name: http
   selector:
     app: system
@@ -47,7 +47,7 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -69,7 +69,7 @@ spec:
       - name: system-container
         image: system:1.0-SNAPSHOT
         ports:
-        - containerPort: 9080
+        - containerPort: 9090
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule

--- a/start/traffic.yaml
+++ b/start/traffic.yaml
@@ -11,13 +11,13 @@ spec:
   - route:
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: blue
       weight: 100
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: green
       weight: 0
@@ -35,13 +35,13 @@ spec:
   - route:
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: blue
       weight: 0
     - destination:
         port:
-          number: 9080
+          number: 9090
         host: system-service
         subset: green
       weight: 100


### PR DESCRIPTION
address issues:
- https://github.com/OpenLiberty/guides-common/issues/1021
- https://github.com/OpenLiberty/guide-microprofile-istio-retry-fallback/issues/122

### Review changes
- [x] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [x] server.xml
  - feature version
- [x] index.html
  - feature version
- [x] update lgdev with `version-update-mp61` branch
- [x] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

